### PR TITLE
fix: strip unknown union members and defer lazy tuples in generator

### DIFF
--- a/packages/jsonrpc-generator/src/openapi-typescript-parser/parse-schema.ts
+++ b/packages/jsonrpc-generator/src/openapi-typescript-parser/parse-schema.ts
@@ -37,12 +37,45 @@ function processPropertyRenaming(
 }
 
 /**
+ * Removes `unknown` members from union types.
+ * An empty schema `{}` in the spec's anyOf (e.g. RpcTransactionResponse)
+ * is emitted by openapi-typescript as `unknown`, which collapses the whole
+ * union (`A | B | unknown` = `unknown`) and breaks discriminator narrowing
+ * and the generated Zod schemas.
+ */
+function stripUnknownFromUnions(property: PropertySignature) {
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const typeNode = property.getTypeNodeOrThrow();
+    const unions = typeNode.isKind(SyntaxKind.UnionType)
+      ? [typeNode, ...typeNode.getDescendantsOfKind(SyntaxKind.UnionType)]
+      : typeNode.getDescendantsOfKind(SyntaxKind.UnionType);
+
+    for (const union of unions) {
+      const members = union.getTypeNodes();
+      const kept = members.filter(
+        (m) => m.getKind() !== SyntaxKind.UnknownKeyword
+      );
+      if (kept.length > 0 && kept.length < members.length) {
+        union.replaceWithText(kept.map((m) => m.getText()).join(" | "));
+        // replaceWithText invalidates descendant nodes, restart the scan
+        changed = true;
+        break;
+      }
+    }
+  }
+}
+
+/**
  * Processes a single schema property and returns its schema type
  */
 function processSchemaProperty(
   property: PropertySignature,
   mappedSnakeCamelProperty: Map<string, string>
 ) {
+  stripUnknownFromUnions(property);
+
   const propertyDescendants = property.getDescendantsOfKind(
     SyntaxKind.PropertySignature
   );

--- a/packages/jsonrpc-generator/src/zod-generator/node-handler.ts
+++ b/packages/jsonrpc-generator/src/zod-generator/node-handler.ts
@@ -171,7 +171,16 @@ export function handleTupleType(
     convertTypeNodeToZod(element, context)
   );
 
-  return createZodTuple(zodTypes);
+  const tuple = createZodTuple(zodTypes);
+
+  // zod v4's $ZodTuple reads item._zod.optin at construction time, which
+  // forces z.lazy items immediately — before forward-referenced schemas are
+  // declared. Defer construction of the whole tuple instead.
+  if (zodTypes.some((zodType) => zodType.includes("z.lazy("))) {
+    return `z.lazy(() => ${tuple})`;
+  }
+
+  return tuple;
 }
 
 /**

--- a/packages/jsonrpc-types/src/schemas.ts
+++ b/packages/jsonrpc-types/src/schemas.ts
@@ -67,8 +67,12 @@ export type AccessKeyPermissionView = "FullAccess" | {
     };
 };
 export type AccessKeyView = {
-    /** Format: uint64 */
+    /**
+     * Format: uint64
+     * @description Current nonce; each transaction signed with this key must use a strictly greater value.
+     */
     nonce: number;
+    /** @description Access scope: full access, or a function-call permission with an optional allowance and method/receiver limits. */
     permission: AccessKeyPermissionView;
 };
 export type AccountContractView = {
@@ -109,18 +113,26 @@ export type AccountInfo = {
     publicKey: PublicKey;
 };
 export type AccountView = {
+    /** @description Liquid (non-staked) account balance, in yoctoNEAR. */
     amount: NearToken;
+    /** @description Hash of the deployed contract code; the all-`1`s hash when no contract is deployed. */
     codeHash: CryptoHash;
+    /** @description Set when the account uses a global contract referenced by the deploying account id. */
     globalContractAccountId?: AccountId | (null);
+    /** @description Set when the account uses a global contract referenced by code hash. */
     globalContractHash?: CryptoHash | (null);
+    /** @description Staked balance locked for validation, in yoctoNEAR. */
     locked: NearToken;
     /**
      * Format: uint64
-     * @description TODO(2271): deprecated.
+     * @description Deprecated and unused. TODO(2271): remove.
      * @default 0
      */
     storagePaidAt: number;
-    /** Format: uint64 */
+    /**
+     * Format: uint64
+     * @description Total storage used by the account, in bytes.
+     */
     storageUsage: number;
 };
 export type AccountWithPublicKey = {
@@ -387,7 +399,7 @@ export type ActionsValidationError = "DeleteActionMustBeFinal" | {
         /** Format: uint64 */
         numberOfDeployActions: number;
     };
-};
+} | "FunctionCallEmptyMethodName";
 export type ActionView = "CreateAccount" | {
     DeployContract: {
         /** Format: bytes */
@@ -3862,12 +3874,13 @@ export type RpcTransactionError = {
     /** @enum {string} */
     name: "INTERNAL_ERROR";
 } | {
+    info?: TimeoutErrorCause | (null);
     /** @enum {string} */
     name: "TIMEOUT_ERROR";
 };
 export type RpcTransactionResponse = {
     finalExecutionStatus: TxExecutionStatus;
-} & (FinalExecutionOutcomeWithReceiptView | FinalExecutionOutcomeView | unknown);
+} & (FinalExecutionOutcomeWithReceiptView | FinalExecutionOutcomeView);
 export type RpcTransactionStatusRequest = {
     /** @default EXECUTED_OPTIMISTIC */
     waitUntil: TxExecutionStatus;
@@ -4047,8 +4060,12 @@ export type RpcViewAccessKeyResponse = {
     blockHash: CryptoHash;
     /** Format: uint64 */
     blockHeight: number;
-    /** Format: uint64 */
+    /**
+     * Format: uint64
+     * @description Current nonce; each transaction signed with this key must use a strictly greater value.
+     */
     nonce: number;
+    /** @description Access scope: full access, or a function-call permission with an optional allowance and method/receiver limits. */
     permission: AccessKeyPermissionView;
 };
 export type RpcViewAccountError = {
@@ -4092,21 +4109,29 @@ export type RpcViewAccountRequest = {
     syncCheckpoint: SyncCheckpoint;
 });
 export type RpcViewAccountResponse = {
+    /** @description Liquid (non-staked) account balance, in yoctoNEAR. */
     amount: NearToken;
     blockHash: CryptoHash;
     /** Format: uint64 */
     blockHeight: number;
+    /** @description Hash of the deployed contract code; the all-`1`s hash when no contract is deployed. */
     codeHash: CryptoHash;
+    /** @description Set when the account uses a global contract referenced by the deploying account id. */
     globalContractAccountId?: AccountId | (null);
+    /** @description Set when the account uses a global contract referenced by code hash. */
     globalContractHash?: CryptoHash | (null);
+    /** @description Staked balance locked for validation, in yoctoNEAR. */
     locked: NearToken;
     /**
      * Format: uint64
-     * @description TODO(2271): deprecated.
+     * @description Deprecated and unused. TODO(2271): remove.
      * @default 0
      */
     storagePaidAt: number;
-    /** Format: uint64 */
+    /**
+     * Format: uint64
+     * @description Total storage used by the account, in bytes.
+     */
     storageUsage: number;
 };
 export type RpcViewCodeError = {
@@ -4207,12 +4232,16 @@ export type RpcViewStateError = {
 };
 export type RpcViewStateRequest = {
     accountId: AccountId;
-    /** @default null */
+    /**
+     * @description Resume listing after this key (exclusive); must start with `prefix`.
+     * @default null
+     */
     afterKeyBase64: StoreKey | (null);
     /** @default false */
     includeProof: boolean;
     /**
      * Format: uint32
+     * @description Maximum number of entries to return in this page.
      * @default null
      */
     limit: number | null;
@@ -4228,6 +4257,7 @@ export type RpcViewStateResponse = {
     blockHash: CryptoHash;
     /** Format: uint64 */
     blockHeight: number;
+    /** @description Cursor to resume from: present when more entries remain, absent when the listing is complete. */
     lastKey?: StoreKey | (null);
     proof?: string[];
     values: StateItem[];
@@ -4460,18 +4490,26 @@ export type StateChangeWithCauseView = {
     /** @description A view of the account */
     change: {
         accountId: AccountId;
+        /** @description Liquid (non-staked) account balance, in yoctoNEAR. */
         amount: NearToken;
+        /** @description Hash of the deployed contract code; the all-`1`s hash when no contract is deployed. */
         codeHash: CryptoHash;
+        /** @description Set when the account uses a global contract referenced by the deploying account id. */
         globalContractAccountId?: AccountId | (null);
+        /** @description Set when the account uses a global contract referenced by code hash. */
         globalContractHash?: CryptoHash | (null);
+        /** @description Staked balance locked for validation, in yoctoNEAR. */
         locked: NearToken;
         /**
          * Format: uint64
-         * @description TODO(2271): deprecated.
+         * @description Deprecated and unused. TODO(2271): remove.
          * @default 0
          */
         storagePaidAt: number;
-        /** Format: uint64 */
+        /**
+         * Format: uint64
+         * @description Total storage used by the account, in bytes.
+         */
         storageUsage: number;
     };
     /** @enum {string} */
@@ -4626,6 +4664,22 @@ export type Tier1ProxyView = {
     addr: string;
     peerId: PublicKey;
 };
+export type TimeoutErrorCause = {
+    /** @enum {string} */
+    cause: "NOT_OBSERVED";
+} | {
+    /** @enum {string} */
+    cause: "PENDING";
+    status: RpcTransactionResponse;
+} | {
+    /** @enum {string} */
+    cause: "DOES_NOT_TRACK_SHARD";
+    shardId: ShardId;
+} | {
+    /** @enum {string} */
+    cause: "ERROR";
+    debugInfo: string;
+};
 export type TrackedShardsConfig = "NoShards" | {
     Shards: ShardUId[];
 } | "AllShards" | {
@@ -4745,6 +4799,7 @@ export type VersionedSignedDelegateAction = {
     signature: Signature;
 };
 export type ViewStateResult = {
+    /** @description Cursor to resume from: present when more entries remain, absent when the listing is complete. */
     lastKey?: StoreKey | (null);
     proof?: string[];
     values: StateItem[];

--- a/packages/jsonrpc-types/src/zod-schemas.ts
+++ b/packages/jsonrpc-types/src/zod-schemas.ts
@@ -26,10 +26,10 @@ export const AccessKeyListSchema = z.object({
 export const AccessKeyPermissionSchema = z.union([z.object({
     FunctionCall: z.lazy(() => FunctionCallPermissionSchema)
 }), z.literal("FullAccess"), z.object({
-    GasKeyFunctionCall: z.tuple([
+    GasKeyFunctionCall: z.lazy(() => z.tuple([
         z.lazy(() => GasKeyInfoSchema),
         z.lazy(() => FunctionCallPermissionSchema)
-    ])
+    ]))
 }), z.object({
     GasKeyFullAccess: z.lazy(() => GasKeyInfoSchema)
 })]);
@@ -305,7 +305,7 @@ export const ActionsValidationErrorSchema = z.union([z.literal("DeleteActionMust
         limit: z.number(),
         numberOfDeployActions: z.number()
     })
-})]);
+}), z.literal("FunctionCallEmptyMethodName")]);
 export const ActionViewSchema = z.union([z.literal("CreateAccount"), z.object({
     DeployContract: z.object({
         code: z.string()
@@ -440,10 +440,10 @@ export const BlockHeaderViewSchema = z.object({
     prevStateRoot: z.lazy(() => CryptoHashSchema),
     randomValue: z.lazy(() => CryptoHashSchema),
     rentPaid: z.lazy(() => NearTokenSchema),
-    shardSplit: z.union([z.tuple([
+    shardSplit: z.union([z.lazy(() => z.tuple([
         z.lazy(() => ShardIdSchema),
         AccountIdSchema
-    ]), z.null()]).optional(),
+    ])), z.null()]).optional(),
     signature: z.lazy(() => SignatureSchema),
     spiceChunkEndorsementStats: z.union([z.array(z.lazy(() => SpiceChunkEndorsementStatsSchema)), z.null()]).optional(),
     timestamp: z.number(),
@@ -2442,11 +2442,12 @@ export const RpcTransactionErrorSchema = z.union([z.object({
     }),
     name: z.literal("INTERNAL_ERROR")
 }), z.object({
+    info: z.union([z.lazy(() => TimeoutErrorCauseSchema), z.null()]).optional(),
     name: z.literal("TIMEOUT_ERROR")
 })]);
 export const RpcTransactionResponseSchema = z.object({
     finalExecutionStatus: z.lazy(() => TxExecutionStatusSchema)
-}).and(z.union([FinalExecutionOutcomeWithReceiptViewSchema, FinalExecutionOutcomeViewSchema, z.unknown()]));
+}).and(z.union([FinalExecutionOutcomeWithReceiptViewSchema, FinalExecutionOutcomeViewSchema]));
 export const RpcTransactionStatusRequestSchema = z.object({
     waitUntil: z.lazy(() => TxExecutionStatusSchema)
 }).and(z.union([z.object({
@@ -2965,6 +2966,18 @@ export const Tier1ProxyViewSchema = z.object({
     addr: z.string(),
     peerId: PublicKeySchema
 });
+export const TimeoutErrorCauseSchema = z.union([z.object({
+    cause: z.literal("NOT_OBSERVED")
+}), z.object({
+    cause: z.literal("PENDING"),
+    status: RpcTransactionResponseSchema
+}), z.object({
+    cause: z.literal("DOES_NOT_TRACK_SHARD"),
+    shardId: ShardIdSchema
+}), z.object({
+    cause: z.literal("ERROR"),
+    debugInfo: z.string()
+})]);
 export const TrackedShardsConfigSchema = z.union([z.literal("NoShards"), z.object({
     Shards: z.array(ShardUIdSchema)
 }), z.literal("AllShards"), z.object({


### PR DESCRIPTION
## Summary
- The nearcore spec declares `RpcTransactionResponse` as `anyOf: [FinalExecutionOutcomeWithReceiptView, FinalExecutionOutcomeView, {}]`. openapi-typescript emits the empty schema as `unknown`, and `A | B | unknown` collapses to `unknown` — breaking the generated discriminator narrowing (DTS build failure, CI red since #45) and widening the Zod union. The parser now strips `unknown` members from unions that have other members.
- zod v4 `$ZodTuple` reads `item._zod.optin` at construction time, forcing `z.lazy` items before forward-referenced schemas are declared — crashing every consumer at import (`GasKeyFunctionCall` tuple). The zod generator now wraps tuples containing `z.lazy` items in `z.lazy(() => ...)`.
- Regenerated `jsonrpc-types` with both fixes; the diff also picks up minor upstream spec drift (doc comments, `FunctionCallEmptyMethodName` variant, `TimeoutErrorCause`).

## Test plan
- Generator jest: 14/14 suites, 100 tests passing
- Root `yarn build`, `yarn test`, `yarn check-types` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)